### PR TITLE
Update cpufreq_conservativex.c

### DIFF
--- a/drivers/cpufreq/cpufreq_conservativex.c
+++ b/drivers/cpufreq/cpufreq_conservativex.c
@@ -30,8 +30,8 @@
  * It helps to keep variable names smaller, simpler
  */
 
-#define DEF_FREQUENCY_UP_THRESHOLD		(70)
-#define DEF_FREQUENCY_DOWN_THRESHOLD		(30)
+#define DEF_FREQUENCY_UP_THRESHOLD		(85)
+#define DEF_FREQUENCY_DOWN_THRESHOLD		(60)
 
 /*
  * The polling frequency of this governor depends on the capability of
@@ -95,7 +95,7 @@ static struct dbs_tuners {
 	.down_threshold = DEF_FREQUENCY_DOWN_THRESHOLD,
 	.sampling_down_factor = DEF_SAMPLING_DOWN_FACTOR,
 	.ignore_nice = 0,
-	.freq_step = 5,
+	.freq_step = 10,
 };
 
 static inline u64 get_cpu_idle_time_jiffy(unsigned int cpu, u64 *wall)


### PR DESCRIPTION
Editing up and down threshold , to avoid erratic scaling for practical usage (SD 805)
Increase frequency step for larger frequency jumps
* Advised to use with no hotplug and enable touch cpu boost to kick out of lags